### PR TITLE
relaxed dependencies

### DIFF
--- a/daisydiff.gemspec
+++ b/daisydiff.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "cocaine", "~> 0.5.1"
-  spec.add_dependency "nokogiri", "~> 1.4.2"
+  spec.add_dependency "cocaine", ">= 0.5.1"
+  spec.add_dependency "nokogiri", ">= 1.4.2"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "ruby-prof"


### PR DESCRIPTION
Relax dependencies, specifically, Nokogiri was giving me issues because we use "1.5.x" and daisydiff locked the version to "1.4.x" 

![daisy](http://www.peteykins.com/images/FarkApr04/daisies.jpg)
